### PR TITLE
feat: maintain reference to refresh-promise to avoid repetitive calls

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -67,7 +67,7 @@ jobs:
 
   publish-npmjs:
     needs: release
-    environment: prod
+    environment: ${{ github.ref_name == 'main' && 'prod' || '' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -85,7 +85,7 @@ jobs:
 
   publish-gitlab:
     needs: release
-    environment: prod
+    environment: ${{ github.ref_name == 'main' && 'prod' || '' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@fundwave/oidc-client",
-  "version": "2.0.0",
+  "version": "2.0.1-retain-refresh-promise-reference.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@fundwave/oidc-client",
-      "version": "2.0.0",
+      "version": "2.0.1-retain-refresh-promise-reference.0",
       "license": "MIT",
       "dependencies": {
         "jwt-decode": "^3.1.2"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@fundwave/oidc-client",
-  "version": "2.0.1-retain-refresh-promise-reference.0",
+  "version": "2.0.1-retain-refresh-promise-reference.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@fundwave/oidc-client",
-      "version": "2.0.1-retain-refresh-promise-reference.0",
+      "version": "2.0.1-retain-refresh-promise-reference.1",
       "license": "MIT",
       "dependencies": {
         "jwt-decode": "^3.1.2"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@fundwave/oidc-client",
-  "version": "2.0.1-retain-refresh-promise-reference.1",
+  "version": "2.0.1-retain-refresh-promise-reference.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@fundwave/oidc-client",
-      "version": "2.0.1-retain-refresh-promise-reference.1",
+      "version": "2.0.1-retain-refresh-promise-reference.2",
       "license": "MIT",
       "dependencies": {
         "jwt-decode": "^3.1.2"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fundwave/oidc-client",
-  "version": "2.0.1-retain-refresh-promise-reference.0",
+  "version": "2.0.1-retain-refresh-promise-reference.1",
   "description": "JS client for making server calls for an OIDC flow",
   "license": "MIT",
   "author": "The Fundwave Authors",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fundwave/oidc-client",
-  "version": "2.0.1-retain-refresh-promise-reference.1",
+  "version": "2.0.1-retain-refresh-promise-reference.2",
   "description": "JS client for making server calls for an OIDC flow",
   "license": "MIT",
   "author": "The Fundwave Authors",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fundwave/oidc-client",
-  "version": "2.0.0",
+  "version": "2.0.1-retain-refresh-promise-reference.0",
   "description": "JS client for making server calls for an OIDC flow",
   "license": "MIT",
   "author": "The Fundwave Authors",


### PR DESCRIPTION
#### Description

store reference to currently ongoing refresh-token network calls to avoid making repetitive calls when
- a lot of calls request token-refreshes simultaneously
- refreshes take longer than 15s (default wait-time for this lib) - can happen if browser is busy with other calls

#### Resolutions
- fixes getfundwave/oidc-client/issues/8

#### Deployment

- Current pipelines will suffice